### PR TITLE
Ensure preferredContentSize is updated after RichTextViewController has updated its content in async dispatched functions

### DIFF
--- a/Sources/RichTextRenderer/ViewController/RichTextViewController.swift
+++ b/Sources/RichTextRenderer/ViewController/RichTextViewController.swift
@@ -157,7 +157,14 @@ open class RichTextViewController: UIViewController, NSLayoutManagerDelegate {
     private func renderDocumentIfNeeded() {
         guard let document = richTextDocument else { return }
 
-        DispatchQueue.main.async {
+        // ----->
+        // When using the renderer in SwiftUI, setting the preferred content size in an async dispatch can lead to
+        // SwiftUI having used the preferred content size already, when the queued change is made. In that case SwiftUI
+        // is not "aware" of the preferred content size having changed, hence will not render the content correctly.
+        //
+        // By disabling the async dispatch, SwiftUI has the right size available, when able to access it. Doing this
+        // with the content we are dealing with did not show any significant performance impact of a blocking execution.
+//        DispatchQueue.main.async {
             var output = self.renderer.render(document: document)
             if self.trimWhitespace {
                 output = output.trim()
@@ -166,7 +173,8 @@ open class RichTextViewController: UIViewController, NSLayoutManagerDelegate {
             self.textStorage.setAttributedString(output)
             self.textStorage.endEditing()
             self.calculateAndSetPreferredContentSize()
-        }
+//        }
+        // <-----
     }
 
     private func calculateAndSetPreferredContentSize() {


### PR DESCRIPTION
When integrating the Contentful library into a project which uses SwiftUI, we noticed that its contents were sometimes not rendered correctly: nothing was displayed at all or the content was only partially rendered.

The root cause was that the UITextView's preferredContentSize was not set / updated correctly when the RichTextViewController made changes in async dispatched functions.

We've been able to fix the rendering of RichTextViewController in the case where it is initialized with `isScrollEnabled: true` by observing changes of the UITextView's `contentSize` property and updating the `preferredContentSize` property of the `RichtTextViewController` upon change.